### PR TITLE
Queries and Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Replace `USER` with the user which has appropriate permissions to the account (h
 
 Most commands typically require a combination of these switches:
 
-    -c [CLOUD URL]
+    -c [CLOUD URL] (Run `info` command on Gateway prompt to get the cloud URL
     -u [USER EMAIL]
     -p [PASSWORD]
     -a [ACCOUNT ID]
@@ -94,7 +94,7 @@ The easiest way to see what the `dcs-tools` can do is to enter the command shell
 
 Do this by using the `shell` command.
 
-    dcs-tools -c https://somecloud.wigwag.io -u USER -p PASS -a acdefgh12312121211221211 shell
+    dcs-tools -c https://somecloud.wigwag.io -u USER -p PASS -a acdefgh1231212121122121? shell
 
 All other commands stated here can be entered in the shell, or can be ran as your `[COMMAND]` when your run `dcs-tools`
 


### PR DESCRIPTION
This repo has issues disabled - @cmnor

I tried running this command `dcs-tools -c https://somecloud.wigwag.io -u USER -p PASS -a acdefgh1231212121122121? shell`

1. Do we have public link for this cloud? Can we add info on which cloud to add?
2. What is required in option -a? How to fetch that?
3. I tried running the command on staging os2 cloud (without -a) option and I got below error.

[2019-05-17T22:20:28.653Z] [ERROR] [dcs-sdk api] Failed (getAuthWithPass):
Trace: [2019-05-17T22:20:28.658Z] [ERROR] [dcs-sdk api] Failed (getAuthWithPass):
    at Logger.error (/home/deepika/edge_repos/enterprise-tools/utils/logger.js:69:25)
    at /home/deepika/edge_repos/enterprise-tools/api.js:134:20
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
ERR>> Failed (doLoginAndGo):  Invalid response: 401 --> Unauthorized

CC @ygoyal18 @enggb 